### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -27,7 +27,7 @@ class action_plugin_semanticdata extends DokuWiki_Action_Plugin {
     /**
      * Registers a callback function for a given event
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('IO_WIKIPAGE_WRITE', 'BEFORE', $this, '_handle');
         $controller->register_hook('HTML_SECEDIT_BUTTON', 'BEFORE', $this, '_editbutton');
         $controller->register_hook('HTML_EDIT_FORMSELECTION', 'BEFORE', $this, '_editform');

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -54,7 +54,7 @@ class syntax_plugin_semanticdata_entry extends DokuWiki_Syntax_Plugin {
 	/**
 	 * Handle the match - parse the data
 	 */
-	function handle($match, $state, $pos, &$handler){
+	function handle($match, $state, $pos, Doku_Handler $handler){
 		// get lines
 		$lines = explode("\n",$match);
 		array_pop($lines);
@@ -101,7 +101,7 @@ class syntax_plugin_semanticdata_entry extends DokuWiki_Syntax_Plugin {
 	/**
 	 * Create output or save the data
 	 */
-	function render($format, &$renderer, $data) {
+	function render($format, Doku_Renderer $renderer, $data) {
 		global $ID;
 		switch ($format){
 			case 'xhtml':

--- a/syntax/table.php
+++ b/syntax/table.php
@@ -56,7 +56,7 @@ class syntax_plugin_semanticdata_table extends DokuWiki_Syntax_Plugin {
 	 * This parsing is shared between the multiple different output/control
 	 * syntaxes
 	 */
-	function handle($match, $state, $pos, &$handler){
+	function handle($match, $state, $pos, Doku_Handler $handler){
 		// get lines and additional class
 		$lines = explode("\n",$match);
 		array_pop($lines);
@@ -172,7 +172,7 @@ class syntax_plugin_semanticdata_table extends DokuWiki_Syntax_Plugin {
 	/**
 	 * Create output
 	 */
-	function render($format, &$R, $data) {
+	function render($format, Doku_Renderer $R, $data) {
 		if($format != 'xhtml') return false;
 		if(is_null($data)) return false;
 		$R->info['cache'] = false;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
